### PR TITLE
Fix layout jump on Tuck gallery, set lazy load

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -247,6 +247,8 @@ dt {
 
 .tuckImage {
   position: relative;
+  width: 350px;
+  height: 250px;
 }
 
 .tuckImage .caption {

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -249,6 +249,7 @@ dt {
   position: relative;
   width: 350px;
   height: 250px;
+  background-color: black;
 }
 
 .tuckImage .caption {

--- a/src/pages/TuckerPage/components/TuckImage.tsx
+++ b/src/pages/TuckerPage/components/TuckImage.tsx
@@ -8,7 +8,7 @@ type TuckImageProps = {
 const TuckImage: React.FC<TuckImageProps> = ({ photo, children }) => (
   <div className="tuckImage">
     <a href={photo.original}>
-      <img src={photo.thumbnail} alt={photo.alt} />
+      <img src={photo.thumbnail} alt={photo.alt} loading="lazy" />
     </a>
     {photo.caption && <div className="caption">{photo.caption}</div>}
     {children && <p>{children}</p>}


### PR DESCRIPTION
- Change `.tuckImage` size to `350x250px` (the size of thumbnails). This prevents the page from jumping and layout shifting as the images load in as they're loaded into a fit size.
- Add `loading="lazy"` to all `img` elements in `.tuckImage`. Support [from all browsers is still lacking](https://caniuse.com/#feat=loading-lazy-attr), but for supported browsers (and particularly on mobile) this should increase the gallery load time a bit while saving data for guests who don't want to see all of Tucker's images (but why would you want that???)
- Add `background-color: black` to `.tuckImage` container to reduce the amount of screen flash that occurs when images load in. Thumbnails always use a black background when generating thumbs that don't fit the `350x250` ratio, so there's a good chance the box will only be partially filled as the thumb loads in.